### PR TITLE
Fix missing key command for sending Tab keystrokes after each entry

### DIFF
--- a/passdmenu.py
+++ b/passdmenu.py
@@ -64,7 +64,7 @@ def xdotool(entries, press_return, delay=None, window_id=None):
 
     commands = [c for e in entries[:-1] for c in (
         "type {} '{}'".format(always_opts, e),
-        always_opts + " Tab")]
+        "key {} Tab".format(always_opts))]
     if len(entries) > 0:
         commands += ["type {} '{}'".format(always_opts, entries[-1])]
     if press_return:


### PR DESCRIPTION
After the code for generating the commands has been restructured to expose the delay option from xdotool in #2, an error has been encountered if `passdmenu` is invoked with `passdmenu -uPt` to type username and password.

Without this pull request, the Tab command for xdotool is generated as follows
`
--clearmodifiers --window 106954762 Tab
` 
which xdotool obviously rejects as an invalid command.
This pull request adds the "key" command into the generated Tab command, so that autotyping username and password works again.
