### PR TITLE
Check if PASSWORD_STORE_DIR is set

### DIFF
--- a/passdmenu.py
+++ b/passdmenu.py
@@ -13,7 +13,8 @@ XCLIP = shutil.which('xclip')
 XDOTOOL = shutil.which('xdotool')
 DMENU = shutil.which('dmenu')
 PASS = shutil.which('pass')
-STORE = path.normpath(path.expanduser('~/.password-store'))
+STORE = os.getenv('PASSWORD_STORE_DIR',
+                  path.normpath(path.expanduser('~/.password-store')))
 XSEL_PRIMARY = "primary"
 
 


### PR DESCRIPTION
Else fall back to the default storedir of pass ($HOME/.password-store)

This closes #7

---

PR for the issue #7 I opened

It looks for PASSWORD_STORE_DIR and if getenv returns None for that it uses the second value (at least it did for me)
