### PR TITLE
Sort choices alphabetically

### DIFF
--- a/passdmenu.py
+++ b/passdmenu.py
@@ -65,6 +65,7 @@ def collect_choices(store, regex=None):
                 full_path = os.path.join(dirsubpath, f[:-4])
                 if not regex or re.match(regex, full_path):
                     choices += [full_path]
+    choices.sort()
     return choices
 
 


### PR DESCRIPTION
Most implementations of a password manager sort the entries alphabetically, so passdmenu should do that too.

Maybe there should also be a option to choose wether the dmenu should be sorted, but that is not part of this pull request.