### PR TITLE
Add '--generate' option to create a password if not existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Help:
     A dmenu frontend to pass. All passed arguments not listed below, are passed to
     dmenu. If you need to pass arguments to dmenu which are in conflict with the
     options below, place them after --. Requires xclip in default 'copy' mode.
-    
+
     optional arguments:
       -h, --help            show this help message and exit
       -c, --copy            Use xclip to copy the username and/or password into
@@ -60,3 +60,8 @@ Help:
                             and -f are forwarded as parameters.The command is
                             executed in addition to and after specified -t, -c
                             options are handled.
+      -g, --generate        Generate a password if not existing. To add a user
+                            enter the password name follow by a dash and by the
+                            username i.e. folder/pass#username.
+      -G, --generate-no-symbols
+                            Generate a password same as -g except with no symbols.


### PR DESCRIPTION
When I want to create an new account on a website, I needed to create a password quickly, that's why I create the option `-g, --generate` and `-G, --generate-no-symbols` to have the password creation process directly in the dmenu.

How it works:
You lauch dmenu and start typing the name of the new password, if it doesn't exist you will have no suggestion and the name you entered will be use to create the password. You could also add the login, just append the password name with a # follow by the login (i.e `web/www.site.com#login@mail.me`). The login will be put in the password file on the second line and won't be part of the password name.